### PR TITLE
Components improve

### DIFF
--- a/src/Algebra/Graph/Algorithm/Internal.hs
+++ b/src/Algebra/Graph/Algorithm/Internal.hs
@@ -1,30 +1,38 @@
 module Algebra.Graph.Algorithm.Internal where
 
-import           Algebra.Graph
+import                            Algebra.Graph
+import Data.DisjointSet           (DisjointSet)
 import qualified Data.DisjointSet as DS
-import qualified Data.Set         as S
 
 -- | Extract disjoint set of connectivity components from the graph
-components :: Ord a => Graph a -> DS.DisjointSet a
+--
+-- >>> DS.pretty $ components ((1 * 2) + (3 * 4))
+-- "{{1,2},{3,4}}"
+--
+-- >>> DS.pretty $ components (((1 * 2) + (3 * 4)) + (2 * 3))
+-- "{{1,2,3,4}}"
+components :: Ord a => Graph a -> DisjointSet a
 components Empty         = DS.empty
 components (Vertex x)    = DS.singleton x
-components (Overlay x y) = mergeComponents (components x) (components y)
-components (Connect x y) = DS.fromLists [vertexList x ++ vertexList y]
+components (Connect x y) = DS.fromLists [extractVertices x <> extractVertices y]
+components (Overlay x y) = (components x) <> (components y)
 
--- | Merge two disjoint sets
-mergeComponents ::
-     Ord a => DS.DisjointSet a -> DS.DisjointSet a -> DS.DisjointSet a
-mergeComponents x y = foldr insertComponent x (DS.toSets y)
-
--- | Insert a set into the other disjoint set structure:
--- Firstly, we find all intersections between the given set `x` and any of
--- disjoint ones. Then we unite all the intersecting sets into one big union
--- and finally append this big union to all other sets, with which we were not
--- intersected.
-insertComponent :: Ord a => S.Set a -> DS.DisjointSet a -> DS.DisjointSet a
-insertComponent x dsu =
-  DS.fromLists (S.toList (S.unions (x : connected)) : disconnected)
+-- | \( O(s) \).
+--
+-- This function extracts all vertices from a given graph.
+-- It is alternative version of VertexList function
+-- but it does not care about duplicates and has better complexity.
+--
+-- >>> extractVertices ((1 * 2) + (3 * 4))
+-- [1,2,3,4]
+extractVertices :: Graph a -> [a]
+extractVertices Empty = []
+extractVertices (Vertex v) = [v]
+extractVertices (Connect l r) = left <> right
   where
-    sets = DS.toSets dsu
-    connected = filter (not . S.disjoint x) sets
-    disconnected = map S.toList (filter (S.disjoint x) sets)
+    left = extractVertices l
+    right = extractVertices r
+extractVertices (Overlay l r) = left <> right
+  where
+    left = extractVertices l
+    right = extractVertices r

--- a/src/Algebra/Graph/Algorithm/Internal.hs
+++ b/src/Algebra/Graph/Algorithm/Internal.hs
@@ -2,37 +2,17 @@ module Algebra.Graph.Algorithm.Internal where
 
 import                            Algebra.Graph
 import Data.DisjointSet           (DisjointSet)
-import qualified Data.DisjointSet as DS
+import qualified Data.DisjointSet as DisjointSet
 
 -- | Extract disjoint set of connectivity components from the graph
 --
--- >>> DS.pretty $ components ((1 * 2) + (3 * 4))
+-- >>> DisjointSet.pretty $ components ((1 * 2) + (3 * 4))
 -- "{{1,2},{3,4}}"
 --
--- >>> DS.pretty $ components (((1 * 2) + (3 * 4)) + (2 * 3))
+-- >>> DisjointSet.pretty $ components (((1 * 2) + (3 * 4)) + (2 * 3))
 -- "{{1,2,3,4}}"
 components :: Ord a => Graph a -> DisjointSet a
-components Empty         = DS.empty
-components (Vertex x)    = DS.singleton x
-components (Connect x y) = DS.fromLists [extractVertices x <> extractVertices y]
-components (Overlay x y) = (components x) <> (components y)
-
--- | \( O(s) \).
---
--- This function extracts all vertices from a given graph.
--- It is alternative version of VertexList function
--- but it does not care about duplicates and has better complexity.
---
--- >>> extractVertices ((1 * 2) + (3 * 4))
--- [1,2,3,4]
-extractVertices :: Graph a -> [a]
-extractVertices Empty = []
-extractVertices (Vertex v) = [v]
-extractVertices (Connect l r) = left <> right
-  where
-    left = extractVertices l
-    right = extractVertices r
-extractVertices (Overlay l r) = left <> right
-  where
-    left = extractVertices l
-    right = extractVertices r
+components Empty           = DisjointSet.empty
+components (Vertex x)      = DisjointSet.singleton x
+components g@(Connect _ _) = DisjointSet.singletons $ vertexSet g
+components (Overlay x y)   = components x <> components y


### PR DESCRIPTION
**Improved version of connectivity components find.** 
Changelog:
1. Replace `vertexList` with self-made `extractVertices` function. It can have duplicates and output is not sorted but it has better time complexity.
2. `DisjointSet` has `Monoid` instance. Functionality in "overlay" section of `component` function can be replaced with `mappend`:
`components (Overlay x y) = (components x) <> (components y)`